### PR TITLE
Add portfolio website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Analyst Portfolio</title>
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            margin: 0;
+            background: #f0f0f5;
+            color: #333;
+        }
+        header {
+            background: linear-gradient(135deg, #6e8efb, #a777e3);
+            color: white;
+            text-align: center;
+            padding: 80px 20px;
+        }
+        header h1 {
+            font-size: 3rem;
+            margin: 0;
+            text-shadow: 1px 1px 4px rgba(0,0,0,0.4);
+        }
+        header p {
+            font-size: 1.2rem;
+            margin: 10px 0 0;
+        }
+        main {
+            max-width: 900px;
+            margin: 40px auto;
+            padding: 0 20px;
+        }
+        section {
+            margin-bottom: 40px;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            padding: 20px;
+        }
+        h2 {
+            border-bottom: 2px solid #a777e3;
+            padding-bottom: 10px;
+            color: #6e8efb;
+        }
+        ul {
+            list-style: none;
+            padding: 0;
+        }
+        ul li::before {
+            content: '✔';
+            color: #6e8efb;
+            margin-right: 8px;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Jane Doe - Data Analyst</h1>
+        <p>4 years of turning data into decisions</p>
+    </header>
+
+    <main>
+        <section>
+            <h2>About Me</h2>
+            <p>Hello! I'm Jane Doe, a data analyst with four years of professional experience. I specialize in transforming complex datasets into actionable insights that drive business success.</p>
+        </section>
+
+        <section>
+            <h2>Skills</h2>
+            <ul>
+                <li>Python</li>
+                <li>Power BI</li>
+                <li>Azure Databricks</li>
+                <li>Jira &amp; Confluence</li>
+                <li>Azure ML</li>
+                <li>Snowflake</li>
+                <li>SQL and PL/SQL</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>Projects</h2>
+            <p>Coming soon!</p>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with a small portfolio page for a data analyst

## Testing
- `pytest -q`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fdaf8cd5c8321bc921eaaeb404892